### PR TITLE
feat: Session/3

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/presentation/splash/splash_page.dart';
 import 'package:flutter_training/presentation/weather/weather_page.dart';
 
 class App extends StatelessWidget {
@@ -6,8 +7,11 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: WeatherPage(),
+    return MaterialApp(
+      home: const SplashPage(),
+      routes: {
+        WeatherPage.routeName: (_) => const WeatherPage(),
+      },
     );
   }
 }

--- a/lib/presentation/splash/splash_page.dart
+++ b/lib/presentation/splash/splash_page.dart
@@ -30,7 +30,12 @@ class _SplashPageState extends State<SplashPage> {
     if (!context.mounted) {
       return;
     }
+
+    // 天気画面に遷移して戻ってくることを待つ
     await Navigator.of(context).pushNamed(WeatherPage.routeName);
+
+    // 天気画面に遷移して、戻ってきたら再度天気画面に遷移する
+    unawaited(_goToWeatherPageAfterFrameCompletes());
   }
 
   @override

--- a/lib/presentation/splash/splash_page.dart
+++ b/lib/presentation/splash/splash_page.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_training/presentation/weather/weather_page.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
@@ -8,6 +11,28 @@ class SplashPage extends StatefulWidget {
 }
 
 class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    unawaited(_goToWeatherPageAfterFrameCompletes());
+    super.initState();
+  }
+
+  Future<void> _goToWeatherPageAfterFrameCompletes() async {
+    // 画面の描写が完了することを待つ
+    await WidgetsBinding.instance.endOfFrame;
+    // 画面の描写が完了した後に、0.5秒待つ
+    await Future<void>.delayed(
+      const Duration(milliseconds: 500),
+    );
+
+    // When a BuildContext is used,
+    // its mounted property must be checked after an asynchronous gap.
+    if (!context.mounted) {
+      return;
+    }
+    await Navigator.of(context).pushNamed(WeatherPage.routeName);
+  }
+
   @override
   Widget build(BuildContext context) {
     return const DecoratedBox(

--- a/lib/presentation/splash/splash_page.dart
+++ b/lib/presentation/splash/splash_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.green,
+      ),
+    );
+  }
+}

--- a/lib/presentation/weather/components/action_buttons.dart
+++ b/lib/presentation/weather/components/action_buttons.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 
 class ActionButtons extends StatelessWidget {
   const ActionButtons({
+    required VoidCallback onCloseButtonPressed,
     required VoidCallback onReloadButtonPressed,
     super.key,
-  }) : _onReloadButtonPressed = onReloadButtonPressed;
+  })  : _onCloseButtonPressed = onCloseButtonPressed,
+        _onReloadButtonPressed = onReloadButtonPressed;
 
+  final VoidCallback _onCloseButtonPressed;
   final VoidCallback _onReloadButtonPressed;
 
   @override
@@ -15,9 +18,7 @@ class ActionButtons extends StatelessWidget {
       children: [
         Flexible(
           child: TextButton(
-            onPressed: () {
-              // TODO: ボタン押下時に何かする
-            },
+            onPressed: _onCloseButtonPressed,
             child: const Text('Close'),
           ),
         ),

--- a/lib/presentation/weather/weather_page.dart
+++ b/lib/presentation/weather/weather_page.dart
@@ -10,6 +10,8 @@ import 'package:yumemi_weather/yumemi_weather.dart';
 class WeatherPage extends StatelessWidget {
   const WeatherPage({super.key});
 
+  static const routeName = '/weather';
+
   @override
   Widget build(BuildContext context) {
     return const Scaffold(

--- a/lib/presentation/weather/weather_page.dart
+++ b/lib/presentation/weather/weather_page.dart
@@ -39,6 +39,10 @@ class _BodyState extends State<_Body> {
   // TODO: 他のレスポンスデータも返却される際に UiState で管理するようにする
   Weather? _weather;
 
+  void _onCloseButtonPressed() {
+    Navigator.of(context).pop();
+  }
+
   Future<void> _onReloadButtonPressed() async {
     final newWeather = await _fetchWeather();
 
@@ -79,6 +83,7 @@ class _BodyState extends State<_Body> {
                     height: 80,
                   ),
                   ActionButtons(
+                    onCloseButtonPressed: _onCloseButtonPressed,
                     onReloadButtonPressed: _onReloadButtonPressed,
                   ),
                 ],


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] StatefulWidget を継承した Widget で構築された新しい画面（以下、スプラッシュ画面）を追加する
- [x] スプラッシュ画面の背景色は Colors.green に設定する
- [x] アプリ起動時にスプラッシュ画面に遷移する
- [x] スプラッシュ画面が表示されたら、0.5 秒後に前回まで作っていた画面（以下、天気画面）に遷移する
- [x] 天気画面の Close ボタンをタップすると画面を閉じる（動作イメージから前画面に戻るという意味で理解した）
- [x] 天気画面からスプラッシュ画面に戻った後、再度 0.5 秒後に天気画面に遷移する

## Next

本 PR で実装した画面遷移周りを [go_router](https://pub.dev/packages/go_router)に書き換える。
別 PR で対応予定です。

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

expected は issue #4 の動作イメージを確認してください。
actual の動作は iPhone 15 Pro Max で確認しています。

| expected | actual |
|----------|--------|
| xxx      | <video src="https://github.com/Kotaro666-dev/flutter-training-202312/assets/54063249/34678b81-8b16-4e11-9a47-0398b36688e9" /> |

